### PR TITLE
Loosened up requirements to allow for more modern versions of depende…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-anytree==2.4.3
-argcomplete==1.9.4
-enum34==1.1.6
-ipaddress==1.0.22
-six==1.11.0
-tabulate==0.8.2
+anytree>=2.4.3,<3
+argcomplete>=1.9.4,<2
+enum34>=1.1.6,<2
+ipaddress>=1.0.22,<2
+six>=1.11.0,<2
+tabulate>=0.8.2,<1


### PR DESCRIPTION
…ncies

The older requirements started giving errors in 3.9, 3.10. This commit will allow any updated version that's not a new major version of the requirement while still setting the existing  minimum version for those on really old Python versions

Closes #11 